### PR TITLE
Add a method to validate the presence of liquid tag 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ ActiveRecord style validations for Liquid content in your ActiveRecord models.
 This gem makes 3 class methods available to your models:
   * `validates_liquid_of` - Ensures that the liquid content is valid and has all opening/closing tags.
   * `validates_presence_of_liquid_variable` - Useful to ensure your user content contains the specified Liquid variable(s).
-  * `validates_presence_of_liquid_tag` - Ensure that your user content contains the specified tag(s) and does not exceed the maximum tag count limit.
+  * `validates_liquid_tag` - Ensure that user content includes the specified tags, but the tag is optional if it is not present and does not exceed the maximum tag count
   
 
 ## Installation
@@ -23,19 +23,19 @@ In it's simplest form:
 class Article < ActiveRecord::Base
   validates_liquid_of :content
   validates_presence_of_liquid_variable :content, variable: 'very_important_variable'
-  validates_presence_of_liquid_tag :content, tag: 'your_tag', max: 1
+  validates_liquid_tag :content, tag: 'your_tag', max: 1
 end
 ```
 
-`validates_presence_of_liquid_tag` takes required `tag` and `max` property
+`validates_liquid_tag` takes required `tag`, `max`  and optional `presence` property
 
-``` ruby
-validates_presence_of_liquid_tag :content, 
+```ruby
+validates_liquid_tag :content, 
                                   tag: 'head_content', 
                                   max: 1
 ```
 
-```
+
 `validates_presence_of_liquid_variable` takes an optional `container` option like this:
 
 ``` ruby

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 ActiveRecord style validations for Liquid content in your ActiveRecord models.
 
-This gem makes 2 class methods available to your models:
+This gem makes 3 class methods available to your models:
   * `validates_liquid_of` - Ensures that the liquid content is valid and has all opening/closing tags.
   * `validates_presence_of_liquid_variable` - Useful to ensure your user content contains the specified Liquid variable(s).
+  * `validates_presence_of_liquid_tag` - Ensure that your user content contains the specified tag(s) and does not exceed the maximum tag count limit.
+  
 
 ## Installation
 
@@ -21,9 +23,19 @@ In it's simplest form:
 class Article < ActiveRecord::Base
   validates_liquid_of :content
   validates_presence_of_liquid_variable :content, variable: 'very_important_variable'
+  validates_presence_of_liquid_tag :content, tag: 'your_tag', max: 1
 end
 ```
 
+`validates_presence_of_liquid_tag` takes required `tag` and `max` property
+
+``` ruby
+validates_presence_of_liquid_tag :content, 
+                                  tag: 'head_content', 
+                                  max: 1
+```
+
+```
 `validates_presence_of_liquid_variable` takes an optional `container` option like this:
 
 ``` ruby

--- a/lib/liquid-validations.rb
+++ b/lib/liquid-validations.rb
@@ -1,8 +1,8 @@
-require 'liquid-validations/version'
+require "liquid-validations/version"
 
 module LiquidValidations
   def validates_liquid_of(*attr_names)
-    configuration = { :message => I18n.translate('activerecord.errors.messages')[:invalid] }
+    configuration = { :message => I18n.translate("activerecord.errors.messages")[:invalid] }
     configuration.update(attr_names.extract_options!)
 
     validates_each attr_names, configuration do |record, attr_name, value|
@@ -10,106 +10,108 @@ module LiquidValidations
 
       begin
         template = Liquid::Template.parse(value.to_s)
-        errors  += template.errors
+        errors += template.errors
       rescue Exception => e
         errors << e.message
       end
 
       for error in errors
-        record.errors.add(:base, friendly_liquid_error(error) + " in your #{ friendly_attr_name(attr_name) }")
+        record.errors.add(:base, friendly_liquid_error(error) + " in your #{friendly_attr_name(attr_name)}")
       end
     end
   end
 
   def validates_presence_of_liquid_variable(*attr_names)
-    configuration = { :message => I18n.translate('activerecord.errors.messages')[:invalid], :variable => nil, :container => nil }
+    configuration = { :message => I18n.translate("activerecord.errors.messages")[:invalid], :variable => nil, :container => nil }
     configuration.update(attr_names.extract_options!)
     raise(ArgumentError, "You must supply a variable to check for") if configuration[:variable].blank?
 
     validates_each attr_names, configuration do |record, attr_name, value|
-      value         = value.to_s
-      variable      = configuration[:variable].to_s
-      variable_re   = /\{\{\s*#{ variable }( .*)?\}\}/
-      container     = configuration[:container].to_s
-      container_re  = /<\s*#{ container }.*>.*#{ variable_re }.*<\/\s*#{ container }\s*>/im
+      value = value.to_s
+      variable = configuration[:variable].to_s
+      variable_re = /\{\{\s*#{variable}( .*)?\}\}/
+      container = configuration[:container].to_s
+      container_re = /<\s*#{container}.*>.*#{variable_re}.*<\/\s*#{container}\s*>/im
 
       if container.blank? && !(value =~ variable_re)
-        record.errors.add(:base, "You must include {{ #{ variable } }} in your #{ friendly_attr_name(attr_name) }")
+        record.errors.add(:base, "You must include {{ #{variable} }} in your #{friendly_attr_name(attr_name)}")
       elsif !container.blank? && !(value =~ container_re)
-        record.errors.add(:base, "You must include {{ #{ variable } }} inside the <#{ container }> tag of your #{ friendly_attr_name(attr_name) }")
+        record.errors.add(:base, "You must include {{ #{variable} }} inside the <#{container}> tag of your #{friendly_attr_name(attr_name)}")
       end
     end
   end
 
   def validates_liquid_tag(*attr_names)
-    configuration = { :message => I18n.translate('activerecord.errors.messages')[:invalid], tag: nil, max: 0, presence: true }
+    configuration = { :message => I18n.translate("activerecord.errors.messages")[:invalid], tag: nil, max: 0, presence: true }
     configuration.update(attr_names.extract_options!)
-    presence = configuration[:presence]
-     
-    if presence.is_a? Proc
-      presence = presence.yield
-    end
-    raise(ArgumentError, 'You must supply a tag and max to check for ') if (configuration[:tag].blank? || configuration[:max].zero? ) && configuration[:presence] 
+
+    raise(ArgumentError, "You must supply a tag and max to check for ") if (configuration[:tag].blank? || configuration[:max].zero?) && configuration[:presence]
     validates_each attr_names, configuration do |record, attr_name, value|
-      value    = value.to_s
-      max      = configuration[:max]
+      presence = configuration[:presence]
+
+      if presence.is_a? Proc
+        presence = presence.yield record
+      end
+      value = value.to_s
+      max = configuration[:max]
       patterns = []
-      tag   = configuration[:tag]
+      tag = configuration[:tag]
       required_tag = ""
       if tag.is_a? Array
         patterns = tag.map do |e|
-            /{%\s+#{e}\s+(.*?)%}/
+          /{%\s+#{e}\s+(.*?)%}/
         end
         tag.each do |ele|
           required_tag << "{% #{ele} %}"
         end
-      if (!(patterns.all? {|p| p =~(value)}) && presence)
-        record.errors.add(:base, "You must supply #{required_tag} in your #{ friendly_attr_name(attr_name) }")
-      elsif presence && check_occurance(patterns, value, max)
-        record.errors.add(:base, "#{friendly_attr_name(attr_name)} must not have more than #{max} #{get_max_tag(tag, value, max)}")
-      elsif !presence && check_occurance(patterns, value, max)
-        record.errors.add(:base, "#{friendly_attr_name(attr_name)} must not have more than #{max} #{get_max_tag(tag, value, max)}")
-      end
+        if (!(patterns.all? { |p| p =~ (value) }) && presence)
+          record.errors.add(:base, "You must supply #{required_tag} in your #{friendly_attr_name(attr_name)}")
+        elsif presence && check_occurance(patterns, value, max)
+          record.errors.add(:base, "#{friendly_attr_name(attr_name)} must not have more than #{max} #{get_max_tag(tag, value, max)}")
+        elsif !presence && check_occurance(patterns, value, max)
+          record.errors.add(:base, "#{friendly_attr_name(attr_name)} must not have more than #{max} #{get_max_tag(tag, value, max)}")
+        end
       else
-      tag =  configuration[:tag].to_s
-      tag_r = /{%\s+#{tag}\s+(.*?)%}/
-      if (!(value =~ tag_r) && presence)
-        record.errors.add(:base, "You must supply {% #{tag} %} in your #{ friendly_attr_name(attr_name) }")
-      elsif presence && (value.scan(tag_r).size > max)
-       record.errors.add(:base, "#{friendly_attr_name(attr_name)} must not have more than #{max} {% #{tag} %}")
-      elsif !presence && (value.scan(tag_r).size > max)
-        record.errors.add(:base, "#{friendly_attr_name(attr_name)} must not have more than #{max} {% #{tag} %}") 
+        tag = configuration[:tag].to_s
+        tag_r = /{%\s+#{tag}\s+(.*?)%}/
+        if (!(value =~ tag_r) && presence)
+          record.errors.add(:base, "You must supply {% #{tag} %} in your #{friendly_attr_name(attr_name)}")
+        elsif presence && (value.scan(tag_r).size > max)
+          record.errors.add(:base, "#{friendly_attr_name(attr_name)} must not have more than #{max} {% #{tag} %}")
+        elsif !presence && (value.scan(tag_r).size > max)
+          record.errors.add(:base, "#{friendly_attr_name(attr_name)} must not have more than #{max} {% #{tag} %}")
+        end
       end
     end
-    end
-    
   end
 
   private
 
-  def check_occurance(patterns, value, max) 
+  def check_occurance(patterns, value, max)
     patterns.each do |p|
       if value.scan(p).size > max
-          return true
+        return true
       end
-     end
+    end
     return false
-   end
+  end
+
   def get_max_tag(tag, value, max)
     max_tag = ""
     tag.each do |ele|
       if value.scan(/{% #{ele} %}/).size > max
         max_tag << "{% #{ele} %}"
       end
-     end
-     max_tag
+    end
+    max_tag
   end
+
   def friendly_attr_name(attr_name)
     attr_name.to_s.humanize.downcase
   end
 
   def friendly_liquid_error(error)
-    error.gsub(/liquid/i, '').gsub(/terminated with regexp:.+/, 'closed')
+    error.gsub(/liquid/i, "").gsub(/terminated with regexp:.+/, "closed")
   end
 end
 

--- a/lib/liquid-validations.rb
+++ b/lib/liquid-validations.rb
@@ -43,17 +43,17 @@ module LiquidValidations
   end
 
   def validates_liquid_tag(*attr_names)
-    configuration = { :message => I18n.translate('activerecord.errors.messages')[:invalid], tag: nil, max: nil, presence: true }
+    configuration = { :message => I18n.translate('activerecord.errors.messages')[:invalid], tag: nil, max: 0, presence: true }
     configuration.update(attr_names.extract_options!)
     
-    raise(ArgumentError, 'You must supply a tag and max to check for ') if (configuration[:tag].blank? || configuration[:max].blank? ) && configuration[:presence] 
+    raise(ArgumentError, 'You must supply a tag and max to check for ') if (configuration[:tag].blank? || configuration[:max].zero? ) && configuration[:presence] 
     validates_each attr_names, configuration do |record, attr_name, value|
       value    = value.to_s
       max      = configuration[:max]
       presence = configuration[:presence]
       tag   = configuration[:tag].to_s
       tag_r = /{%\s+#{tag}\s+(.*?)%}/
-      if !(value =~ tag_r)
+      if (!(value =~ tag_r) && presence)
         record.errors.add(:base, "You must supply {% #{tag} %} in your #{ friendly_attr_name(attr_name) }")
       elsif presence && (value.scan(tag_r).size > max)
        record.errors.add(:base, "#{friendly_attr_name(attr_name)} must not have more than #{max} {% #{tag} %}")

--- a/lib/liquid-validations.rb
+++ b/lib/liquid-validations.rb
@@ -56,9 +56,9 @@ module LiquidValidations
       if !(value =~ tag_r)
         record.errors.add(:base, "You must supply {% #{tag} %} in your #{ friendly_attr_name(attr_name) }")
       elsif presence && (value.scan(tag_r).size > max)
-       record.errors.add(:base, "#{friendly_attr_name(attr_name)} must not have more than max tags #{max}")
+       record.errors.add(:base, "#{friendly_attr_name(attr_name)} must not have more than #{max} {% #{tag} %}")
       elsif !presence && (value.scan(tag_r).size > max)
-        record.errors.add(:base, "#{friendly_attr_name(attr_name)} must not have more than max tags #{max}") 
+        record.errors.add(:base, "#{friendly_attr_name(attr_name)} must not have more than #{max} {% #{tag} %}") 
       end
     end
     

--- a/lib/liquid-validations.rb
+++ b/lib/liquid-validations.rb
@@ -42,20 +42,23 @@ module LiquidValidations
     end
   end
 
-  def validates_presence_of_liquid_tag(*attr_names)
-    configuration = { :message => I18n.translate('activerecord.errors.messages')[:invalid], tag: nil, max: nil }
+  def validates_liquid_tag(*attr_names)
+    configuration = { :message => I18n.translate('activerecord.errors.messages')[:invalid], tag: nil, max: nil, presence: true }
     configuration.update(attr_names.extract_options!)
     
-    raise(ArgumentError, 'You must supply a tag or max to check for ') if configuration[:tag].blank? || configuration[:max].blank? 
+    raise(ArgumentError, 'You must supply a tag and max to check for ') if (configuration[:tag].blank? || configuration[:max].blank? ) && configuration[:presence] 
     validates_each attr_names, configuration do |record, attr_name, value|
       value    = value.to_s
       max      = configuration[:max]
+      presence = configuration[:presence]
       tag   = configuration[:tag].to_s
       tag_r = /{%\s+#{tag}\s+(.*?)%}/
       if !(value =~ tag_r)
         record.errors.add(:base, "You must supply {% #{tag} %} in your #{ friendly_attr_name(attr_name) }")
-      elsif max && (value.scan(tag_r).size > max)
+      elsif presence && (value.scan(tag_r).size > max)
        record.errors.add(:base, "#{friendly_attr_name(attr_name)} must not have more than max tags #{max}")
+      elsif !presence && (value.scan(tag_r).size > max)
+        record.errors.add(:base, "#{friendly_attr_name(attr_name)} must not have more than max tags #{max}") 
       end
     end
     

--- a/spec/liquid_validations_spec.rb
+++ b/spec/liquid_validations_spec.rb
@@ -71,7 +71,7 @@ describe LiquidValidations do
     describe 'When tag presence is false ' do
       before do
         Mixin.instance_eval do
-          validates_liquid_tag :content, :tag => 'josh_is_awesome', presence: false, max: 2
+          validates_liquid_tag :content, :tag => 'john_is_awesome', presence: false, max: 2
         end
         @mixin = Mixin.new    
       end
@@ -80,19 +80,31 @@ describe LiquidValidations do
       end
 
       it 'must be invalid when tag is greater than max count' do
-        @mixin.content = '{% josh_is_awesome %} {% josh_is_awesome %} {% josh_is_awesome %}'
+        @mixin.content = '{% john_is_awesome %} {% john_is_awesome %} {% john_is_awesome %}'
         @mixin.valid?
-        @mixin.errors.full_messages.any? { |e| e == "content must not have more than 2 {% josh_is_awesome %}"}.must_equal true
+        @mixin.errors.full_messages.any? { |e| e == "content must not have more than 2 {% john_is_awesome %}"}.must_equal true
       end
 
       it 'must be valid when tag less than max' do
-        @mixin.content = '{% josh_is_awesome %} '
+        @mixin.content = '{% john_is_awesome %} '
         @mixin.valid?
-        @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal false
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% john_is_awesome %} in your content"}.must_equal false
+      end
+
+      it 'must be valid when the content does not include the tag' do
+        @mixin.content = '{% name %} '
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% john_is_awesome %} in your content"}.must_equal false
+      end
+
+      it 'must be valid when the content is nil' do
+        @mixin.content = nil
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% john_is_awesome %} in your content"}.must_equal false
       end
 
       it 'must be valid when tag equal to max' do
-        @mixin.content = '{% josh_is_awesome %} {% josh_is_awesome %}'
+        @mixin.content = '{% john_is_awesome %} {% john_is_awesome %}'
         @mixin.valid?
         @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal false
       end

--- a/spec/liquid_validations_spec.rb
+++ b/spec/liquid_validations_spec.rb
@@ -79,43 +79,19 @@ describe LiquidValidations do
      proc { Mixin.instance_eval { validates_presence_of_liquid_tag :content, tag: 'josh_is_awesome'} }.must_raise ArgumentError
    end
 
-   it 'the record should be invalid when the specified tag and max is not present' do
-     @mixin.content = 'josh_is_awesome'
-     @mixin.valid?.must_equal false
-   end
-
    it 'should include the errors in the errors object' do
      @mixin.content = 'josh_is_awesome'
      @mixin.valid?
      @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal true
    end
 
-  
    it 'must be valid when include tag' do
      @mixin.content = '{% josh_is_awesome %} '
      @mixin.valid?
      @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal false
    end
 
-   it 'must be valid when tag is less than or equal max count' do
-     @mixin.content = '{% josh_is_awesome %} {% josh_is_awesome %}'
-     @mixin.valid?
-     @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal false
-   end
-
-   it 'must be invalid when tag is greater than max count' do
-     @mixin.content = '{% josh_is_awesome %} {% josh_is_awesome %} {% josh_is_awesome %}'
-     @mixin.valid?
-     @mixin.errors.full_messages.any? { |e| e == "content must not have more than max tags 2"}.must_equal true
-   end
-
-   it 'must be valid when using more complex tag' do
-     @mixin.content = "{% josh_is_awesome foobar, data-required='true' %}"
-     @mixin.valid?
-     @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal false
-   end
-
-   it 'must be invalid when using more complex tag' do
+    it 'must be valid when using more complex tag' do
      @mixin.content = "{% josh_is_awesome foobar, data-required='true' %}"
      @mixin.valid?
      @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal false
@@ -156,11 +132,17 @@ describe LiquidValidations do
      @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal true
    end
 
-   it 'must be invalid when tag is greater than max count' do
+   it 'must be valid when tag like {% josh_is_awesome %} {% josh_is_awesome %} {% josh_is_' do
      @mixin.content = '{% josh_is_awesome %} {% josh_is_awesome %} {% josh_is_'
      @mixin.valid?
      @mixin.errors.full_messages.any? { |e| e == "content must not have more than max tags 2"}.must_equal false
    end
+
+   it 'must be invalid when tag is greater than max count' do
+    @mixin.content = '{% josh_is_awesome %} {% josh_is_awesome %} {% josh_is_awesome %}'
+    @mixin.valid?
+    @mixin.errors.full_messages.any? { |e| e == "content must not have more than max tags 2"}.must_equal true
+  end
 
  end
 end

--- a/spec/liquid_validations_spec.rb
+++ b/spec/liquid_validations_spec.rb
@@ -12,8 +12,8 @@ describe LiquidValidations do
     Mixin.must_respond_to(:validates_presence_of_liquid_variable)
   end
 
-  it 'should provide the validates_presence_of_liquid_tag method to ActiveRecord subclasses' do
-    Mixin.must_respond_to(:validates_presence_of_liquid_tag)
+  it 'should provide the validates_liquid_tag method to ActiveRecord subclasses' do
+    Mixin.must_respond_to(:validates_liquid_tag)
   end
 
   describe '.validates_liquid_of' do
@@ -67,82 +67,117 @@ describe LiquidValidations do
     end
   end
 
-  describe '.validates_presence_of_liquid_tag' do
-    before do
-     Mixin.instance_eval do
-       validates_presence_of_liquid_tag :content, :tag => 'josh_is_awesome', max: 2
-     end
-     @mixin = Mixin.new    
-   end
+  describe '.validates_liquid_tag' do
+    describe 'When tag presence is false ' do
+      before do
+        Mixin.instance_eval do
+          validates_liquid_tag :content, :tag => 'josh_is_awesome', presence: false, max: 2
+        end
+        @mixin = Mixin.new    
+      end
+      it 'must be valid if there is no tag' do
+        proc { Mixin.instance_eval { validates_liquid_tag :content, presence: false} }.must_be_silent 
+      end
 
-   it 'must be configured properly' do
-     proc { Mixin.instance_eval { validates_presence_of_liquid_tag :content, tag: 'josh_is_awesome'} }.must_raise ArgumentError
-   end
+      it 'must be invalid when tag is greater than max count' do
+        @mixin.content = '{% josh_is_awesome %} {% josh_is_awesome %} {% josh_is_awesome %}'
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "content must not have more than max tags 2"}.must_equal true
+      end
 
-   it 'should include the errors in the errors object' do
-     @mixin.content = 'josh_is_awesome'
-     @mixin.valid?
-     @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal true
-   end
+      it 'must be valid when tag less than max' do
+        @mixin.content = '{% josh_is_awesome %} '
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal false
+      end
 
-   it 'must be valid when include tag' do
-     @mixin.content = '{% josh_is_awesome %} '
-     @mixin.valid?
-     @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal false
-   end
+      it 'must be valid when tag equal to max' do
+        @mixin.content = '{% josh_is_awesome %} {% josh_is_awesome %}'
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal false
+      end
+
+    end
+    describe 'When tag presence is true by default' do
+      before do
+      Mixin.instance_eval do
+        validates_liquid_tag :content, :tag => 'josh_is_awesome', max: 2
+      end
+      @mixin = Mixin.new    
+    end
+
+    it 'must be configured properly' do
+      proc { Mixin.instance_eval { validates_liquid_tag :content, :tag => 'josh_is_awesome'} }.must_raise ArgumentError
+    end
+
+    it 'must be configured properly' do
+      proc { Mixin.instance_eval { validates_liquid_tag :content} }.must_raise ArgumentError
+    end
+
+    it 'should include the errors in the errors object' do
+      @mixin.content = 'josh_is_awesome'
+      @mixin.valid?
+      @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal true
+    end
+
+    it 'must be valid when include tag' do
+      @mixin.content = '{% josh_is_awesome %} '
+      @mixin.valid?
+      @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal false
+    end
 
     it 'must be valid when using more complex tag' do
-     @mixin.content = "{% josh_is_awesome foobar, data-required='true' %}"
-     @mixin.valid?
-     @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal false
-   end
+      @mixin.content = "{% josh_is_awesome foobar, data-required='true' %}"
+      @mixin.valid?
+      @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal false
+    end
 
-   it 'must be invalid when using tag like { josh_is_awesome }' do
-     @mixin.content = "{ josh_is_awesome }"
-     @mixin.valid?
-     @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal true
-   end
+    it 'must be invalid when using tag like { josh_is_awesome }' do
+      @mixin.content = "{ josh_is_awesome }"
+      @mixin.valid?
+      @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal true
+    end
 
-   it 'must be invalid when using tag like {% josh_is_awesome }' do
-     @mixin.content = "{% josh_is_awesome }"
-     @mixin.valid?
-     @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal true
-   end
+    it 'must be invalid when using tag like {% josh_is_awesome }' do
+      @mixin.content = "{% josh_is_awesome }"
+      @mixin.valid?
+      @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal true
+    end
 
-   it 'must be invalid when using tag like { josh_is_awesome %}' do
-     @mixin.content = "{ josh_is_awesome %}"
-     @mixin.valid?
-     @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal true
-   end
+    it 'must be invalid when using tag like { josh_is_awesome %}' do
+      @mixin.content = "{ josh_is_awesome %}"
+      @mixin.valid?
+      @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal true
+    end
 
-   it 'must be invalid when using tag like {%% josh_is_awesome %%}' do
-     @mixin.content = "{%% josh_is_awesome %%}"
-     @mixin.valid?
-     @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal true
-   end
+    it 'must be invalid when using tag like {%% josh_is_awesome %%}' do
+      @mixin.content = "{%% josh_is_awesome %%}"
+      @mixin.valid?
+      @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal true
+    end
 
-   it 'must be invalid when using tag like %{ josh_is_awesome }%' do
-     @mixin.content = "%{ josh_is_awesome }%"
-     @mixin.valid?
-     @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal true
-   end
+    it 'must be invalid when using tag like %{ josh_is_awesome }%' do
+      @mixin.content = "%{ josh_is_awesome }%"
+      @mixin.valid?
+      @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal true
+    end
 
-   it 'must be invalid when using tag like empty content' do
-     @mixin.valid?
-     @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal true
-   end
+    it 'must be invalid when using tag like empty content' do
+      @mixin.valid?
+      @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal true
+    end
 
-   it 'must be valid when tag like {% josh_is_awesome %} {% josh_is_awesome %} {% josh_is_' do
-     @mixin.content = '{% josh_is_awesome %} {% josh_is_awesome %} {% josh_is_'
-     @mixin.valid?
-     @mixin.errors.full_messages.any? { |e| e == "content must not have more than max tags 2"}.must_equal false
-   end
+    it 'must be valid when tag like {% josh_is_awesome %} {% josh_is_awesome %} {% josh_is_' do
+      @mixin.content = '{% josh_is_awesome %} {% josh_is_awesome %} {% josh_is_'
+      @mixin.valid?
+      @mixin.errors.full_messages.any? { |e| e == "content must not have more than max tags 2"}.must_equal false
+    end
 
-   it 'must be invalid when tag is greater than max count' do
-    @mixin.content = '{% josh_is_awesome %} {% josh_is_awesome %} {% josh_is_awesome %}'
-    @mixin.valid?
-    @mixin.errors.full_messages.any? { |e| e == "content must not have more than max tags 2"}.must_equal true
+    it 'must be invalid when tag is greater than max count' do
+      @mixin.content = '{% josh_is_awesome %} {% josh_is_awesome %} {% josh_is_awesome %}'
+      @mixin.valid?
+      @mixin.errors.full_messages.any? { |e| e == "content must not have more than max tags 2"}.must_equal true
+    end
   end
-
  end
 end

--- a/spec/liquid_validations_spec.rb
+++ b/spec/liquid_validations_spec.rb
@@ -1,22 +1,22 @@
-require_relative 'spec_helper'
+require_relative "spec_helper"
 
 class Mixin < ActiveRecord::Base
 end
 
 describe LiquidValidations do
-  it 'should provide the validates_liquid_of method to ActiveRecord subclasses' do
+  it "should provide the validates_liquid_of method to ActiveRecord subclasses" do
     Mixin.must_respond_to(:validates_liquid_of)
   end
 
-  it 'should provide the validates_presence_of_liquid_variable method to ActiveRecord subclasses' do
+  it "should provide the validates_presence_of_liquid_variable method to ActiveRecord subclasses" do
     Mixin.must_respond_to(:validates_presence_of_liquid_variable)
   end
 
-  it 'should provide the validates_liquid_tag method to ActiveRecord subclasses' do
+  it "should provide the validates_liquid_tag method to ActiveRecord subclasses" do
     Mixin.must_respond_to(:validates_liquid_tag)
   end
 
-  describe '.validates_liquid_of' do
+  describe ".validates_liquid_of" do
     before do
       Mixin.instance_eval do
         validates_liquid_of :content
@@ -26,246 +26,258 @@ describe LiquidValidations do
       @mixin.errors.clear
     end
 
-    [ ' {{ Bad liquid ',
-      ' {% Bad liquid ',
-      '{% for %}{% endfor' ].each do |bad_liquid|
-      it "the record should be invalid when there is a liquid parsing error for #{ bad_liquid }" do
+    [" {{ Bad liquid ",
+     " {% Bad liquid ",
+     "{% for %}{% endfor"].each do |bad_liquid|
+      it "the record should be invalid when there is a liquid parsing error for #{bad_liquid}" do
         @mixin.content = bad_liquid
         @mixin.valid?.must_equal false
       end
     end
 
-    it 'should include the errors in the errors object' do
-      @mixin.content = '{{ unclosed variable '
+    it "should include the errors in the errors object" do
+      @mixin.content = "{{ unclosed variable "
       @mixin.valid?
       @mixin.errors.full_messages.any? { |e| e == "Variable '{{' was not properly closed in your content" }.must_equal true
     end
   end
 
-  describe '.validates_presence_of_liquid_variable' do
+  describe ".validates_presence_of_liquid_variable" do
     before do
       Mixin.instance_eval do
-        validates_presence_of_liquid_variable :content, :variable => 'josh_is_awesome'
+        validates_presence_of_liquid_variable :content, :variable => "josh_is_awesome"
       end
 
       @mixin = Mixin.new
     end
 
-    it 'must be configured properly' do
+    it "must be configured properly" do
       proc { Mixin.instance_eval { validates_presence_of_liquid_variable :content } }.must_raise ArgumentError
     end
 
-    it 'the record should be invalid when the specified variable is not present' do
-      @mixin.content = '{{ josh_is_not_awesome }}'
+    it "the record should be invalid when the specified variable is not present" do
+      @mixin.content = "{{ josh_is_not_awesome }}"
       @mixin.valid?.must_equal false
     end
 
-    it 'should include the errors in the errors object' do
-      @mixin.content = '{{ josh_is_not_awesome }}'
+    it "should include the errors in the errors object" do
+      @mixin.content = "{{ josh_is_not_awesome }}"
       @mixin.valid?
       @mixin.errors.full_messages.any? { |e| e == "You must include {{ josh_is_awesome }} in your content" }.must_equal true
     end
   end
 
-  describe '.validates_liquid_tag' do
-    describe 'When presence is a proc' do
+  describe ".validates_liquid_tag" do
+    describe "When presence is a proc" do
       before do
+        # proc = Proc.new { self.verification_method == "sms" }
         Mixin.instance_eval do
-          validates_liquid_tag :content, :tag => ['Joh', 'meshu@gmail.com', '2518063'], max: 2, presence: Proc.new {true}
+          validates_liquid_tag :content, :tag => ["Joh", "meshu@gmail.com", "2518063"], max: 2, presence: ->(user) { user.verification_method == "sms" }, if: :verification_method?
         end
-        @mixin = Mixin.new    
+        @mixin = Mixin.new
+        p Mixin.column_names
       end
-      it 'must be valid when the content is nil' do
+      it "must be valid when the content is nil" do
         @mixin.content = nil
         @mixin.valid?
-        @mixin.errors.full_messages.any? { |e| e == "You must supply {% Joh %}{% meshu@gmail.com %}{% 2518063 %} in your content"}.must_equal true
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% Joh %}{% meshu@gmail.com %}{% 2518063 %} in your content" }.must_equal false
       end
-      it 'must be valid when the content is Joh' do
+      it "must be valid when the content is Joh" do
         @mixin.content = "{% Joh %}{% meshu@gmail.com %}{% 2518063 %}"
         @mixin.valid?
-        @mixin.errors.full_messages.any? { |e| e == "You must supply {% Joh %}{% meshu@gmail.com %}{% 2518063 %} in your content"}.must_equal false
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% Joh %}{% meshu@gmail.com %}{% 2518063 %} in your content" }.must_equal false
+      end
+      it "must be invalid when the content is nil and the verification_method is sms" do
+        @mixin.content = nil
+        @mixin.verification_method = "sms"
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% Joh %}{% meshu@gmail.com %}{% 2518063 %} in your content" }.must_equal true
+      end
+
+      it "must be invalid when the verification_method is email" do
+        @mixin.content = "{% Joh %}{% meshu@gmail.com %}{% 2518063 %}"
+        @mixin.verification_method = "email"
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% Joh %}{% meshu@gmail.com %}{% 2518063 %} in your content" }.must_equal false
       end
     end
-    describe 'When tag contanis array of tag and presence is false' do
+    describe "When tag contanis array of tag and presence is false" do
       before do
         Mixin.instance_eval do
-          validates_liquid_tag :content, :tag => ['Joh', 'meshu@gmail.com', '2518063'], max: 2, presence: false
+          validates_liquid_tag :content, :tag => ["Joh", "meshu@gmail.com", "2518063"], max: 2, presence: false
         end
-        @mixin = Mixin.new    
+        @mixin = Mixin.new
       end
-      it 'must be valid when the content is nil' do
+      it "must be valid when the content is nil" do
         @mixin.content = nil
         @mixin.valid?
-        @mixin.errors.full_messages.any? { |e| e == "content must not have more than 2 {% Joh %}"}.must_equal false
+        @mixin.errors.full_messages.any? { |e| e == "content must not have more than 2 {% Joh %}" }.must_equal false
       end
 
       it "must be valid when we include all tags in our content" do
         @mixin.content = "{% Joh %} {% Joh %} {% meshu@gmail.com %} {% 2518063 %}"
         @mixin.valid?
-        @mixin.errors.full_messages.any? { |e| e == "You must supply {% Joh %}{% meshu@gmail.com %}{% 2518063 %} in your content"}.must_equal false
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% Joh %}{% meshu@gmail.com %}{% 2518063 %} in your content" }.must_equal false
       end
 
-      it 'must be invalid when tag is greater than max count' do
+      it "must be invalid when tag is greater than max count" do
         @mixin.content = "{% Joh %} {% Joh %} {% Joh %} {% meshu@gmail.com %} {% 2518063 %}"
         @mixin.valid?
-        @mixin.errors.full_messages.any? { |e| e == "content must not have more than 2 {% Joh %}"}.must_equal true
+        @mixin.errors.full_messages.any? { |e| e == "content must not have more than 2 {% Joh %}" }.must_equal true
       end
-      
     end
-    describe 'When tag contanis array of tag and presence is true' do
+    describe "When tag contanis array of tag and presence is true" do
       before do
         Mixin.instance_eval do
-          validates_liquid_tag :content, :tag => ['meshu', 'meshu@gmail.com', '2518063'], max: 2
+          validates_liquid_tag :content, :tag => ["meshu", "meshu@gmail.com", "2518063"], max: 2
         end
-        @mixin = Mixin.new    
+        @mixin = Mixin.new
       end
       it "must be invalid when we didn't include all tags in our content" do
         @mixin.content = "{% meshu %} {% meshu@gmail.com %}"
         @mixin.valid?
-        @mixin.errors.full_messages.any? { |e| e == "You must supply {% meshu %}{% meshu@gmail.com %}{% 2518063 %} in your content"}.must_equal true
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% meshu %}{% meshu@gmail.com %}{% 2518063 %} in your content" }.must_equal true
       end
 
       it "must be valid when we include all tags in our content" do
         @mixin.content = "{% meshu %} {% meshu@gmail.com %} {% 2518063 %}"
         @mixin.valid?
-        @mixin.errors.full_messages.any? { |e| e == "You must supply {% meshu %}{% meshu@gmail.com %}{% 2518063 %} in your content"}.must_equal false
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% meshu %}{% meshu@gmail.com %}{% 2518063 %} in your content" }.must_equal false
       end
-      
+
       it "must be valid when we include all tags in our content" do
         @mixin.content = "{% meshu %} {% meshu %} {% meshu@gmail.com %} {% 2518063 %}"
         @mixin.valid?
-        @mixin.errors.full_messages.any? { |e| e == "You must supply {% meshu %}{% meshu@gmail.com %}{% 2518063 %} in your content"}.must_equal false
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% meshu %}{% meshu@gmail.com %}{% 2518063 %} in your content" }.must_equal false
       end
 
-      it 'must be invalid when tag is greater than max count' do
+      it "must be invalid when tag is greater than max count" do
         @mixin.content = "{% meshu %} {% meshu %} {% meshu %} {% meshu@gmail.com %} {% 2518063 %}"
         @mixin.valid?
-        @mixin.errors.full_messages.any? { |e| e == "content must not have more than 2 {% meshu %}"}.must_equal true
+        @mixin.errors.full_messages.any? { |e| e == "content must not have more than 2 {% meshu %}" }.must_equal true
       end
-      
     end
-    describe 'When tag presence is false' do
+    describe "When tag presence is false" do
       before do
         Mixin.instance_eval do
-          validates_liquid_tag :content, :tag => 'john_is_awesome', presence: false, max: 2
+          validates_liquid_tag :content, :tag => "john_is_awesome", presence: false, max: 2
         end
-        @mixin = Mixin.new    
+        @mixin = Mixin.new
       end
-      it 'must be valid if there is no tag' do
-        proc { Mixin.instance_eval { validates_liquid_tag :content, presence: false} }.must_be_silent 
+      it "must be valid if there is no tag" do
+        proc { Mixin.instance_eval { validates_liquid_tag :content, presence: false } }.must_be_silent
       end
 
-      it 'must be invalid when tag is greater than max count' do
-        @mixin.content = '{% john_is_awesome %} {% john_is_awesome %} {% john_is_awesome %}'
+      it "must be invalid when tag is greater than max count" do
+        @mixin.content = "{% john_is_awesome %} {% john_is_awesome %} {% john_is_awesome %}"
         @mixin.valid?
-        @mixin.errors.full_messages.any? { |e| e == "content must not have more than 2 {% john_is_awesome %}"}.must_equal true
+        @mixin.errors.full_messages.any? { |e| e == "content must not have more than 2 {% john_is_awesome %}" }.must_equal true
       end
 
-      it 'must be valid when tag less than max' do
-        @mixin.content = '{% john_is_awesome %} '
+      it "must be valid when tag less than max" do
+        @mixin.content = "{% john_is_awesome %} "
         @mixin.valid?
-        @mixin.errors.full_messages.any? { |e| e == "You must supply {% john_is_awesome %} in your content"}.must_equal false
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% john_is_awesome %} in your content" }.must_equal false
       end
 
-      it 'must be valid when the content does not include the tag' do
-        @mixin.content = '{% name %} '
+      it "must be valid when the content does not include the tag" do
+        @mixin.content = "{% name %} "
         @mixin.valid?
-        @mixin.errors.full_messages.any? { |e| e == "You must supply {% john_is_awesome %} in your content"}.must_equal false
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% john_is_awesome %} in your content" }.must_equal false
       end
 
-      it 'must be valid when the content is nil' do
+      it "must be valid when the content is nil" do
         @mixin.content = nil
         @mixin.valid?
-        @mixin.errors.full_messages.any? { |e| e == "You must supply {% john_is_awesome %} in your content"}.must_equal false
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% john_is_awesome %} in your content" }.must_equal false
       end
 
-      it 'must be valid when tag equal to max' do
-        @mixin.content = '{% john_is_awesome %} {% john_is_awesome %}'
+      it "must be valid when tag equal to max" do
+        @mixin.content = "{% john_is_awesome %} {% john_is_awesome %}"
         @mixin.valid?
-        @mixin.errors.full_messages.any? { |e| e == "You must supply {% john_is_awesome %} in your content"}.must_equal false
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% john_is_awesome %} in your content" }.must_equal false
       end
-
     end
-    describe 'When tag presence is true by default' do
+    describe "When tag presence is true by default" do
       before do
-      Mixin.instance_eval do
-        validates_liquid_tag :content, :tag => 'josh_is_awesome', max: 2
+        Mixin.instance_eval do
+          validates_liquid_tag :content, :tag => "josh_is_awesome", max: 2
+        end
+        @mixin = Mixin.new
       end
-      @mixin = Mixin.new    
-    end
 
-    it 'must be configured properly' do
-      proc { Mixin.instance_eval { validates_liquid_tag :content, :tag => 'josh_is_awesome'} }.must_raise ArgumentError
-    end
+      it "must be configured properly" do
+        proc { Mixin.instance_eval { validates_liquid_tag :content, :tag => "josh_is_awesome" } }.must_raise ArgumentError
+      end
 
-    it 'must be configured properly' do
-      proc { Mixin.instance_eval { validates_liquid_tag :content} }.must_raise ArgumentError
-    end
+      it "must be configured properly" do
+        proc { Mixin.instance_eval { validates_liquid_tag :content } }.must_raise ArgumentError
+      end
 
-    it 'should include the errors in the errors object' do
-      @mixin.content = 'josh_is_awesome'
-      @mixin.valid?
-      @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal true
-    end
+      it "should include the errors in the errors object" do
+        @mixin.content = "josh_is_awesome"
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content" }.must_equal true
+      end
 
-    it 'must be valid when include tag' do
-      @mixin.content = '{% josh_is_awesome %} '
-      @mixin.valid?
-      @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal false
-    end
+      it "must be valid when include tag" do
+        @mixin.content = "{% josh_is_awesome %} "
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content" }.must_equal false
+      end
 
-    it 'must be valid when using more complex tag' do
-      @mixin.content = "{% josh_is_awesome foobar, data-required='true' %}"
-      @mixin.valid?
-      @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal false
-    end
+      it "must be valid when using more complex tag" do
+        @mixin.content = "{% josh_is_awesome foobar, data-required='true' %}"
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content" }.must_equal false
+      end
 
-    it 'must be invalid when using tag like { josh_is_awesome }' do
-      @mixin.content = "{ josh_is_awesome }"
-      @mixin.valid?
-      @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal true
-    end
+      it "must be invalid when using tag like { josh_is_awesome }" do
+        @mixin.content = "{ josh_is_awesome }"
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content" }.must_equal true
+      end
 
-    it 'must be invalid when using tag like {% josh_is_awesome }' do
-      @mixin.content = "{% josh_is_awesome }"
-      @mixin.valid?
-      @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal true
-    end
+      it "must be invalid when using tag like {% josh_is_awesome }" do
+        @mixin.content = "{% josh_is_awesome }"
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content" }.must_equal true
+      end
 
-    it 'must be invalid when using tag like { josh_is_awesome %}' do
-      @mixin.content = "{ josh_is_awesome %}"
-      @mixin.valid?
-      @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal true
-    end
+      it "must be invalid when using tag like { josh_is_awesome %}" do
+        @mixin.content = "{ josh_is_awesome %}"
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content" }.must_equal true
+      end
 
-    it 'must be invalid when using tag like {%% josh_is_awesome %%}' do
-      @mixin.content = "{%% josh_is_awesome %%}"
-      @mixin.valid?
-      @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal true
-    end
+      it "must be invalid when using tag like {%% josh_is_awesome %%}" do
+        @mixin.content = "{%% josh_is_awesome %%}"
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content" }.must_equal true
+      end
 
-    it 'must be invalid when using tag like %{ josh_is_awesome }%' do
-      @mixin.content = "%{ josh_is_awesome }%"
-      @mixin.valid?
-      @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal true
-    end
+      it "must be invalid when using tag like %{ josh_is_awesome }%" do
+        @mixin.content = "%{ josh_is_awesome }%"
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content" }.must_equal true
+      end
 
-    it 'must be invalid when using tag like empty content' do
-      @mixin.valid?
-      @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal true
-    end
+      it "must be invalid when using tag like empty content" do
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content" }.must_equal true
+      end
 
-    it 'must be valid when tag like {% josh_is_awesome %} {% josh_is_awesome %} {% josh_is_' do
-      @mixin.content = '{% josh_is_awesome %} {% josh_is_awesome %} {% josh_is_'
-      @mixin.valid?
-      @mixin.errors.full_messages.any? { |e| e == "content must not have more than 2 {% josh_is_awesome %}"}.must_equal false
-    end
+      it "must be valid when tag like {% josh_is_awesome %} {% josh_is_awesome %} {% josh_is_" do
+        @mixin.content = "{% josh_is_awesome %} {% josh_is_awesome %} {% josh_is_"
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "content must not have more than 2 {% josh_is_awesome %}" }.must_equal false
+      end
 
-    it 'must be invalid when tag is greater than max count' do
-      @mixin.content = '{% josh_is_awesome %} {% josh_is_awesome %} {% josh_is_awesome %}'
-      @mixin.valid?
-      @mixin.errors.full_messages.any? { |e| e == "content must not have more than 2 {% josh_is_awesome %}"}.must_equal true
+      it "must be invalid when tag is greater than max count" do
+        @mixin.content = "{% josh_is_awesome %} {% josh_is_awesome %} {% josh_is_awesome %}"
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "content must not have more than 2 {% josh_is_awesome %}" }.must_equal true
+      end
     end
   end
- end
 end

--- a/spec/liquid_validations_spec.rb
+++ b/spec/liquid_validations_spec.rb
@@ -82,7 +82,7 @@ describe LiquidValidations do
       it 'must be invalid when tag is greater than max count' do
         @mixin.content = '{% josh_is_awesome %} {% josh_is_awesome %} {% josh_is_awesome %}'
         @mixin.valid?
-        @mixin.errors.full_messages.any? { |e| e == "content must not have more than max tags 2"}.must_equal true
+        @mixin.errors.full_messages.any? { |e| e == "content must not have more than 2 {% josh_is_awesome %}"}.must_equal true
       end
 
       it 'must be valid when tag less than max' do
@@ -170,13 +170,13 @@ describe LiquidValidations do
     it 'must be valid when tag like {% josh_is_awesome %} {% josh_is_awesome %} {% josh_is_' do
       @mixin.content = '{% josh_is_awesome %} {% josh_is_awesome %} {% josh_is_'
       @mixin.valid?
-      @mixin.errors.full_messages.any? { |e| e == "content must not have more than max tags 2"}.must_equal false
+      @mixin.errors.full_messages.any? { |e| e == "content must not have more than 2 {% josh_is_awesome %}"}.must_equal false
     end
 
     it 'must be invalid when tag is greater than max count' do
       @mixin.content = '{% josh_is_awesome %} {% josh_is_awesome %} {% josh_is_awesome %}'
       @mixin.valid?
-      @mixin.errors.full_messages.any? { |e| e == "content must not have more than max tags 2"}.must_equal true
+      @mixin.errors.full_messages.any? { |e| e == "content must not have more than 2 {% josh_is_awesome %}"}.must_equal true
     end
   end
  end

--- a/spec/liquid_validations_spec.rb
+++ b/spec/liquid_validations_spec.rb
@@ -68,7 +68,83 @@ describe LiquidValidations do
   end
 
   describe '.validates_liquid_tag' do
-    describe 'When tag presence is false ' do
+    describe 'When presence is a proc' do
+      before do
+        Mixin.instance_eval do
+          validates_liquid_tag :content, :tag => ['Joh', 'meshu@gmail.com', '2518063'], max: 2, presence: Proc.new {true}
+        end
+        @mixin = Mixin.new    
+      end
+      it 'must be valid when the content is nil' do
+        @mixin.content = nil
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% Joh %}{% meshu@gmail.com %}{% 2518063 %} in your content"}.must_equal true
+      end
+      it 'must be valid when the content is Joh' do
+        @mixin.content = "{% Joh %}{% meshu@gmail.com %}{% 2518063 %}"
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% Joh %}{% meshu@gmail.com %}{% 2518063 %} in your content"}.must_equal false
+      end
+    end
+    describe 'When tag contanis array of tag and presence is false' do
+      before do
+        Mixin.instance_eval do
+          validates_liquid_tag :content, :tag => ['Joh', 'meshu@gmail.com', '2518063'], max: 2, presence: false
+        end
+        @mixin = Mixin.new    
+      end
+      it 'must be valid when the content is nil' do
+        @mixin.content = nil
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "content must not have more than 2 {% Joh %}"}.must_equal false
+      end
+
+      it "must be valid when we include all tags in our content" do
+        @mixin.content = "{% Joh %} {% Joh %} {% meshu@gmail.com %} {% 2518063 %}"
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% Joh %}{% meshu@gmail.com %}{% 2518063 %} in your content"}.must_equal false
+      end
+
+      it 'must be invalid when tag is greater than max count' do
+        @mixin.content = "{% Joh %} {% Joh %} {% Joh %} {% meshu@gmail.com %} {% 2518063 %}"
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "content must not have more than 2 {% Joh %}"}.must_equal true
+      end
+      
+    end
+    describe 'When tag contanis array of tag and presence is true' do
+      before do
+        Mixin.instance_eval do
+          validates_liquid_tag :content, :tag => ['meshu', 'meshu@gmail.com', '2518063'], max: 2
+        end
+        @mixin = Mixin.new    
+      end
+      it "must be invalid when we didn't include all tags in our content" do
+        @mixin.content = "{% meshu %} {% meshu@gmail.com %}"
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% meshu %}{% meshu@gmail.com %}{% 2518063 %} in your content"}.must_equal true
+      end
+
+      it "must be valid when we include all tags in our content" do
+        @mixin.content = "{% meshu %} {% meshu@gmail.com %} {% 2518063 %}"
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% meshu %}{% meshu@gmail.com %}{% 2518063 %} in your content"}.must_equal false
+      end
+      
+      it "must be valid when we include all tags in our content" do
+        @mixin.content = "{% meshu %} {% meshu %} {% meshu@gmail.com %} {% 2518063 %}"
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% meshu %}{% meshu@gmail.com %}{% 2518063 %} in your content"}.must_equal false
+      end
+
+      it 'must be invalid when tag is greater than max count' do
+        @mixin.content = "{% meshu %} {% meshu %} {% meshu %} {% meshu@gmail.com %} {% 2518063 %}"
+        @mixin.valid?
+        @mixin.errors.full_messages.any? { |e| e == "content must not have more than 2 {% meshu %}"}.must_equal true
+      end
+      
+    end
+    describe 'When tag presence is false' do
       before do
         Mixin.instance_eval do
           validates_liquid_tag :content, :tag => 'john_is_awesome', presence: false, max: 2
@@ -106,7 +182,7 @@ describe LiquidValidations do
       it 'must be valid when tag equal to max' do
         @mixin.content = '{% john_is_awesome %} {% john_is_awesome %}'
         @mixin.valid?
-        @mixin.errors.full_messages.any? { |e| e == "You must supply {% josh_is_awesome %} in your content"}.must_equal false
+        @mixin.errors.full_messages.any? { |e| e == "You must supply {% john_is_awesome %} in your content"}.must_equal false
       end
 
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ def setup_db
   ActiveRecord::Schema.define(:version => 1) do
     create_table :mixins do |t|
       t.column :content, :text
+      t.column :verification_method, :string
       t.column :created_at, :datetime
       t.column :updated_at, :datetime
     end
@@ -28,7 +29,7 @@ def teardown_db
   end
 end
 
-class MiniTest::Spec
+class Minitest::Spec
   before do
     setup_db
   end


### PR DESCRIPTION
In this PR I have done the following changes 

- On `spec/liquid_validations_spec.rb` line 1 change `require 'spec_helper'` to `require_relative 'spec_helper'`
- Added a method `validates_liquid_tag` to `liquid-validations.rb` file
- Added a test to verify the functionality of the `validates_liquid_tag` method
- Added how to user validates_liquid_tag` method to README file